### PR TITLE
Add Generator::send() wrapper as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.2"
+        "phpunit/phpunit": "^7.2",
+        "symfony/var-dumper": "^4.1"
     }
 }

--- a/src/ThrowableGenerator.php
+++ b/src/ThrowableGenerator.php
@@ -22,8 +22,8 @@ class ThrowableGenerator implements IteratorAggregate
 {
     /** @var Generator */
     private $inner;
-    /** @var */
-    private $lastException;
+    /** @var Throwable */
+    private $exception;
 
     public function __construct(Generator $inner)
     {
@@ -36,9 +36,9 @@ class ThrowableGenerator implements IteratorAggregate
             retry:
             yield $item;
 
-            if ($this->lastException) {
-                $item = $this->inner->throw($this->lastException);
-                $this->lastException = null;
+            if ($this->exception) {
+                $item = $this->inner->throw($this->exception);
+                $this->exception = null;
 
                 // $item may be missing if the inner generator ended
                 if ($this->inner->valid()) {
@@ -50,6 +50,6 @@ class ThrowableGenerator implements IteratorAggregate
 
     public function throw(Throwable $e)
     {
-        $this->lastException = $e;
+        $this->exception = $e;
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace glen\ThrowableGenerator\Tests;
 
+use Generator;
 use glen\ThrowableGenerator\ThrowableGenerator;
 use InvalidArgumentException;
 use Throwable;
@@ -12,6 +13,10 @@ class GeneratorTest extends TestCase
     private $throwing = [];
     private $catched = [];
 
+    /**
+     * Without the wrapper, processed items are:
+     *  [ 1, 2, 4, 6 ]
+     */
     public function testIteratorReceivesAllItems()
     {
         $generator = $this->getIterator(range(1, 6));
@@ -34,7 +39,7 @@ class GeneratorTest extends TestCase
         $this->assertEquals([2, 4, 6], $this->catched);
     }
 
-    private function getIterator($items)
+    private function getIterator($items): Generator
     {
         foreach ($items as $item) {
             try {

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -14,12 +14,15 @@ class GeneratorTest extends TestCase
     private $catched = [];
 
     /**
-     * Without the wrapper, processed items are:
-     *  [ 1, 2, 4, 6 ]
+     * @dataProvider sequenceProvider
      */
-    public function testIteratorReceivesAllItems()
-    {
-        $generator = $this->getIterator(range(1, 6));
+    public function testIteratorReceivesAllItems(
+        array $items,
+        array $expectedProcessed,
+        array $expectedThrows,
+        array $expectedCatches
+    ) {
+        $generator = $this->getIterator($items);
         $generator = new ThrowableGenerator($generator);
 
         foreach ($generator as $item) {
@@ -34,9 +37,9 @@ class GeneratorTest extends TestCase
                 $generator->throw($e);
             }
         }
-        $this->assertEquals([1, 2, 3, 4, 5, 6], $this->processed);
-        $this->assertEquals([2, 4, 6], $this->throwing);
-        $this->assertEquals([2, 4, 6], $this->catched);
+        $this->assertEquals($expectedProcessed, $this->processed);
+        $this->assertEquals($expectedThrows, $this->throwing);
+        $this->assertEquals($expectedCatches, $this->catched);
     }
 
     private function getIterator($items): Generator
@@ -49,5 +52,27 @@ class GeneratorTest extends TestCase
                 $this->catched[] = $e->getMessage();
             }
         }
+    }
+
+    public function sequenceProvider(): array
+    {
+        return [
+            /**
+             * Without the wrapper, processed items are:
+             *  [ 1, 2, 4, 6 ]
+             */
+            [
+                range(1, 6),
+                [1, 2, 3, 4, 5, 6],
+                [2, 4, 6],
+                [2, 4, 6],
+            ],
+            [
+                range(1, 9),
+                [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                [2, 4, 6, 8],
+                [2, 4, 6, 8],
+            ],
+        ];
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -57,6 +57,12 @@ class GeneratorTest extends TestCase
     public function sequenceProvider(): array
     {
         return [
+            [
+                range(1, 2),
+                [1, 2],
+                [2],
+                [2],
+            ],
             /**
              * Without the wrapper, processed items are:
              *  [ 1, 2, 4, 6 ]

--- a/tests/SenderTest.php
+++ b/tests/SenderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace glen\ThrowableGenerator\Tests;
+
+use Generator;
+use glen\ThrowableGenerator\ThrowableGenerator;
+
+class SenderTest extends TestCase
+{
+    private $processed = [];
+    private $values = [];
+
+    /**
+     * without the wrapper $processed items are:
+     *  [1, 3, 5]
+     * and $values:
+     *  [1, null, 3, null, 5, null]
+     */
+    public function testSendReceivesAllValues()
+    {
+        $generator = $this->getIterator(range(1, 6));
+        $generator = new ThrowableGenerator($generator);
+
+        foreach ($generator as $item) {
+            $this->processed[] = $item;
+            $generator->send($item);
+        }
+        $this->assertEquals([1, 2, 3, 4, 5, 6], $this->processed);
+        $this->assertEquals([1, 2, 3, 4, 5, 6], $this->values);
+    }
+
+    private function getIterator($items): Generator
+    {
+        foreach ($items as $item) {
+            $this->values[] = yield $item;
+        }
+    }
+}

--- a/tests/SenderTest.php
+++ b/tests/SenderTest.php
@@ -40,6 +40,12 @@ class SenderTest extends TestCase
     public function sequenceProvider(): array
     {
         return [
+            [
+                range(1, 2),
+                [1, 2],
+                [1, 2],
+                [2],
+            ],
             /**
              * without the wrapper $processed items are:
              *  [1, 3, 5]

--- a/tests/SenderTest.php
+++ b/tests/SenderTest.php
@@ -10,23 +10,24 @@ class SenderTest extends TestCase
     private $processed = [];
     private $values = [];
 
+
     /**
-     * without the wrapper $processed items are:
-     *  [1, 3, 5]
-     * and $values:
-     *  [1, null, 3, null, 5, null]
+     * @dataProvider sequenceProvider
      */
-    public function testSendReceivesAllValues()
-    {
-        $generator = $this->getIterator(range(1, 6));
+    public function testSendReceivesAllValues(
+        array $items,
+        array $expectedProcessed,
+        array $expectedValues
+    ) {
+        $generator = $this->getIterator($items);
         $generator = new ThrowableGenerator($generator);
 
         foreach ($generator as $item) {
             $this->processed[] = $item;
             $generator->send($item);
         }
-        $this->assertEquals([1, 2, 3, 4, 5, 6], $this->processed);
-        $this->assertEquals([1, 2, 3, 4, 5, 6], $this->values);
+        $this->assertEquals($expectedProcessed, $this->processed);
+        $this->assertEquals($expectedValues, $this->values);
     }
 
     private function getIterator($items): Generator
@@ -34,5 +35,27 @@ class SenderTest extends TestCase
         foreach ($items as $item) {
             $this->values[] = yield $item;
         }
+    }
+
+    public function sequenceProvider(): array
+    {
+        return [
+            /**
+             * without the wrapper $processed items are:
+             *  [1, 3, 5]
+             * and $values:
+             *  [1, null, 3, null, 5, null]
+             */
+            [
+                range(1, 6),
+                [1, 2, 3, 4, 5, 6],
+                [1, 2, 3, 4, 5, 6],
+            ],
+            [
+                range(1, 9),
+                [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Generator::send() behaves similarly to Generator::throw() that method return value is taken from Iterator, meaning that top level iterator will lose values from iteration.

NOTE: currently mixing `::send` and `::throw` will produce undefined results.